### PR TITLE
remove --context

### DIFF
--- a/pipelines/aws-ecs.yaml
+++ b/pipelines/aws-ecs.yaml
@@ -1,5 +1,5 @@
 # To execute this pipeline, from repo directory shell something like:
-# pypyr aws-ecs --context ./input/aws-ecs.yaml
+# pypyr aws-ecs ./input/aws-ecs.yaml
 # There's no real need to put the context config in a separate yaml, but in the
 # case of ecs where task definitions can take a lot of config, it's sort of
 # handy to keep it in its own yaml file. You can pretty much poach the boto3

--- a/pipelines/aws-s3.yaml
+++ b/pipelines/aws-s3.yaml
@@ -3,7 +3,7 @@
 # WARNING: Will be working with ./out dir - if you have anything in there you
 # want to keep or not potentially overwrite, don't run this.
 # To execute this pipeline, from repo directory shell something like:
-# pypyr aws-s3 --context "bucket=myuniquebucketname"
+# pypyr aws-s3 "bucket=myuniquebucketname"
 # Obviously set myuniquebucketname to a bucket to which your user account has
 # write permissions.
 context_parser: pypyr.parser.keyvaluepairs

--- a/pipelines/aws-s3fetch.yaml
+++ b/pipelines/aws-s3fetch.yaml
@@ -1,7 +1,7 @@
 # WARNING: Using aws costs money. This script does not delete any resources it
 # creates - if you don't want surprise bills, you need to delete these yourself.
 # To execute this pipeline, from repo directory shell something like:
-# pypyr aws-s3fetch --context "bucket=myuniquebucketname"
+# pypyr aws-s3fetch "bucket=myuniquebucketname"
 # Obviously set myuniquebucketname to a bucket to which your user account has
 # write permissions.
 # The echo step in each instance just uses the echoMe value that's set in the

--- a/pipelines/contextset.yaml
+++ b/pipelines/contextset.yaml
@@ -1,5 +1,5 @@
 # To execute this pipeline, from repo directory shell something like:
-# pypyr contextset --context invalue='passed from the cmd args'
+# pypyr contextset "invalue='passed from the cmd args'"
 context_parser: pypyr.parser.keyvaluepairs
 steps:
   - name: pypyr.steps.contextset

--- a/pipelines/env_variables.yaml
+++ b/pipelines/env_variables.yaml
@@ -1,5 +1,5 @@
 # To execute this pipeline, from repo directory shell something like:
-# pypyr env_variables --context "key1=value1,key2=value2"
+# pypyr env_variables "key1=value1,key2=value2"
 context_parser: pypyr.parser.keyvaluepairs
 steps:
   - name: pypyr.steps.env

--- a/pipelines/jsonfilein.yaml
+++ b/pipelines/jsonfilein.yaml
@@ -1,5 +1,5 @@
 # To execute this pipeline, from repo directory shell something like:
-# pypyr jsonfilein --context ./testfiles/sample.json
+# pypyr jsonfilein ./testfiles/sample.json
 context_parser: pypyr.parser.jsonfile
 steps:
   - pypyr.steps.echo # if there's an echoMe in the json, it'll echo here.

--- a/pipelines/list-parser.yaml
+++ b/pipelines/list-parser.yaml
@@ -1,5 +1,5 @@
 # To execute this pipeline, from repo directory shell something like:
-# pypyr list-parser --context "eggs,bacon,ham"
+# pypyr list-parser "eggs,bacon,ham"
 context_parser: pypyr.parser.list
 steps:
   - name: pypyr.steps.echo

--- a/pipelines/list-parser.yaml
+++ b/pipelines/list-parser.yaml
@@ -1,0 +1,8 @@
+# To execute this pipeline, from repo directory shell something like:
+# pypyr list-parser --context "eggs,bacon,ham"
+context_parser: pypyr.parser.list
+steps:
+  - name: pypyr.steps.echo
+    description: the arg passed into the pypyr cmd end up as a list in context under key argList
+    in:
+      echoMe: "the 2nd thing on the input list is: {argList[1]}"

--- a/pipelines/pype-child.yaml
+++ b/pipelines/pype-child.yaml
@@ -1,5 +1,5 @@
 # To execute this pipeline, from repo directory shell something like:
-# pypyr pype-child --context="fromParent=set from cli arg string"
+# pypyr pype-child "fromParent=set from cli arg string"
 # You can run this pipeline directly by itself per above. Or you can invoke it
 # from another pipeline - see pype.yaml for a parent pipeline that calls this
 # pype-child.

--- a/pipelines/pype-recursion-child.yaml
+++ b/pipelines/pype-recursion-child.yaml
@@ -1,9 +1,7 @@
-# To execute this pipeline, from repo directory shell something like:
-# pypyr pype-recursion-child --context='counter=0'
-# This pipeline invokes a child pipeline, pype-recursion-child. It's part of
-# a recursion demo where a parent and a child call each other recursively.
-# You can run this child pipeline directly, or you can run the parent as entry
-# point.
+# This is part of a recursion demo where a parent and a child call each other
+# recursively.
+# Run the parent as entry point:
+# pypyr pype-recursion 'counter=0'
 context_parser: pypyr.parser.keyvaluepairs
 steps:
   - name: pypyr.steps.echo

--- a/pipelines/pype-recursion.yaml
+++ b/pipelines/pype-recursion.yaml
@@ -1,5 +1,5 @@
 # To execute this pipeline, from repo directory shell something like:
-# pypyr pype-recursion --context='counter=0'
+# pypyr pype-recursion 'counter=0'
 # This pipeline invokes a child pipeline, pype-recursion-child. The child
 # pipeline recursively invokes this parent pipeline in turn.
 context_parser: pypyr.parser.keyvaluepairs

--- a/pipelines/pypyr-pipeline-anatomy.yaml
+++ b/pipelines/pypyr-pipeline-anatomy.yaml
@@ -4,7 +4,7 @@
 # Don't run this, it's just an example. The modules don't exist.
 
 # optional
-# A context_parser parses the pypyr --context input argument.
+# A context_parser parses the pypyr context input argument (the 2nd arg).
 context_parser: my.custom.parser
 
 # mandatory.

--- a/pipelines/slack.yaml
+++ b/pipelines/slack.yaml
@@ -1,6 +1,6 @@
 # edit ./testfiles/credentials.yaml to set slackToken
 # To execute this pipeline, from repo directory shell something like:
-# pypyr slack --context ./testfiles/credentials.yaml
+# pypyr slack ./testfiles/credentials.yaml
 context_parser: pypyr.parser.yamlfile
 steps:
   - name: pypyrslack.steps.send

--- a/pipelines/stepdecorators.yaml
+++ b/pipelines/stepdecorators.yaml
@@ -1,5 +1,5 @@
 # To execute this pipeline, from repo directory shell something like:
-# pypyr stepdecorators --context "isRetry=true,isDebug=true,isDebug=1,ignoreError=True"
+# pypyr stepdecorators "isRetry=true,isDebug=true,isDebug=1,ignoreError=True"
 # Notice how the isRetry flag is used to influence whether certain steps run in the pipeline
 context_parser: pypyr.parser.keyvaluepairs
 steps:

--- a/pipelines/substitutions.yaml
+++ b/pipelines/substitutions.yaml
@@ -1,5 +1,5 @@
 # To execute this pipeline, from repo directory shell something like:
-# pypyr substitutions --context "key1=this is key1 in context,key2=pipe"
+# pypyr substitutions "key1=this is key1 in context,key2=pipe"
 context_parser: pypyr.parser.keyvaluepairs
 steps:
   - name: pypyr.steps.safeshell

--- a/pipelines/tar.yaml
+++ b/pipelines/tar.yaml
@@ -1,7 +1,7 @@
 # WARNING: Will be working with ./out dir - if you have anything in there you
 # want to keep or not potentially overwrite, don't run this.
 # To execute this pipeline, from repo directory shell something like:
-# pypyr tar --context fileName='myarchive'
+# pypyr tar fileName='myarchive'
 context_parser: pypyr.parser.keyvaluepairs
 steps:
   - name: pypyr.steps.shell

--- a/pipelines/yamlfilein.yaml
+++ b/pipelines/yamlfilein.yaml
@@ -1,5 +1,5 @@
 # To execute this pipeline, from repo directory shell something like:
-# pypyr yamlfilein --context ./testfiles/sample.yaml
+# pypyr yamlfilein ./testfiles/sample.yaml
 context_parser: pypyr.parser.yamlfile
 steps:
   - pypyr.steps.echo # if there's an echoMe in the yaml, it'll echo here.


### PR DESCRIPTION
- remove --context arg from all help text. it's now positional rather than flagged.
- add list parser example