### PR TITLE
globbing, file writing, new context input dicts

### DIFF
--- a/pipelines/assert.yaml
+++ b/pipelines/assert.yaml
@@ -25,50 +25,51 @@ steps:
       k1: value 1
       k11: value 1
       k2: value 2
-      assertThis: True
+      assert:
+        this: True
   - name: pypyr.steps.assert
     in:
-      assertThis: '{replaceMe}'
+      assert:
+        this: '{replaceMe}'
   - name: pypyr.steps.assert
     description: string substitutions - different variables resolve to same value.
     in:
-      assertThis: '{k1}'
-      assertEquals: '{k11}'
+      assert:
+        this: '{k1}'
+        equals: '{k11}'
   - name: pypyr.steps.assert
     description: numbers are equal
     in:
-      assertThis: 123
-      assertEquals: 123.0
+      assert:
+          this: 123
+          equals: 0123.0
   - name: pypyr.steps.assert
     description: compare two complex types - list with nested dictionaries.
     in:
-      assertThis: '{complexThing1}'
-      assertEquals: '{complexThing2}'
-  - name: pypyr.steps.contextclear
-    in:
-      contextClear:
-        - assertThis
-        - assertEquals
+      assert:
+        this: '{complexThing1}'
+        equals: '{complexThing2}'
   - name: pypyr.steps.assert
     description: numbers are equal
     in:
-      assertThis: 123
-      assertEquals: 123.0
+      assert:
+        this: 123
+        equals: 123.0
   - name: pypyr.steps.assert
     description: compare an int and an int fetched by a str formatting expression.
     in:
       meaningOfLife: 42
-      assertThis: '{meaningOfLife}'
-      assertEquals: 42
-  - name: pypyr.steps.contextclear
+      assert:
+        this: '{meaningOfLife}'
+        equals: 42
+  - name: pypyr.steps.echo
     in:
-      contextClear:
-        - assertThis
-        - assertEquals
+      echoMe: the next negative assert will stop the pipeline
   - name: pypyr.steps.assert
     description: you shall not pass!
     in:
-      assertThis: '{statusValue}'
+      assert:
+        this: '{statusValue}'
   - name: pypyr.steps.echo
     in:
       echoMe: if you made it this far, something went wrong.

--- a/pipelines/debug.yaml
+++ b/pipelines/debug.yaml
@@ -1,0 +1,47 @@
+# To execute this pipeline, from repo directory shell something like:
+# pypyr debug
+steps:
+  - name: pypyr.steps.debug
+    description: print a single key
+    in:
+      k1:
+        k1.1: v1.1
+        k1.2:
+          k1.2.1: v1.2.1
+          k1.2.2: '{k2[k2.1]}'
+        k1.3: v1.3
+      k2:
+        k2.1: v2.1
+      debug:
+        keys: k1
+  - name: pypyr.steps.debug
+    description: print a bunch of keys
+    in:
+      debug:
+        keys: [k1, k2]
+  - name: pypyr.steps.debug
+    description: print a bunch of keys, alternative list format
+    in:
+      debug:
+        keys:
+          - k1
+          - k2
+  - name: pypyr.steps.debug
+    description: print a single key with formatting
+    in:
+      debug:
+        keys: k1
+        format: True
+  - name: pypyr.steps.contextclear
+    description: clearing the debug key from previous step
+    in:
+      contextClear:
+        - debug
+  # you can run debug as a simple step without specifying any inputs.
+  # this will dump the entire context to output.
+  - pypyr.steps.debug
+  - name: pypyr.steps.debug
+    description: print entire context with string formatting applied
+    in:
+      debug:
+        format: True

--- a/pipelines/env_variables.yaml
+++ b/pipelines/env_variables.yaml
@@ -5,9 +5,10 @@ steps:
   - name: pypyr.steps.env
     description: set $ARB_ENV1 and $ARB_ENV2
     in:
-      envSet:
-        ARB_ENV1: 'from_{key1}_context'
-        ARB_ENV2: 'string set in pipeline yaml'
+      env:
+        set:
+          ARB_ENV1: 'from_{key1}_context'
+          ARB_ENV2: 'string set in pipeline yaml'
   - name: pypyr.steps.shell
     description: show the $ARB_ENV1 and $ARB_ENV2 env vars was set by previous step
     in:
@@ -15,22 +16,21 @@ steps:
   - name: pypyr.steps.env
     description: write $ARB_ENV1 and $ARB_ENV2 into the pypyr context as context1 and context2.
     in:
-      envGet:
-        context1: ARB_ENV1
-        context2: ARB_ENV2
+      env:
+        get:
+          context1: ARB_ENV1
+          context2: ARB_ENV2
   - name: pypyr.steps.py
     description: show context values that envget got from $ENVs
     in:
       pycode: print(f"pypyr context values were set from env vars. '{context['context1']}' from ARB_ENV1 and '{context['context2']}' from ARB_ENV2")
   - name: pypyr.steps.env
-    description: |
-                  unset the $ENVs just created. At this point envSet and envGet
-                  are actually still in context from the previous steps, so this
-                  step will actually do envGet, envSet and then unSet.
+    description: unset the $ENVs just created.
     in:
-      envUnset:
-        - ARB_ENV1
-        - ARB_ENV2
+      env:
+        unset:
+          - ARB_ENV1
+          - ARB_ENV2
   - name: pypyr.steps.shell
     description: show the $ARB_ENV1 and $ARB_ENV2 are empty now
     in:
@@ -38,16 +38,17 @@ steps:
   - name: pypyr.steps.env
     description: all in one
     in:
-      envGet:
+      env:
+        get:
           key2: PWD
           key4: USER
-      envSet:
+        set:
           ARB_SET_ME1: 'value 4'
           ARB_SET_ME2: 'go go {key2} end end'
-      envUnset:
+        unset:
           - ARB_SET_ME1
           - ARB_SET_ME2
   - name: pypyr.steps.shell
     description: show context values for key2 and key4 from previous step
     in:
-      cmd: echo this is key2, containing PWD - {key2} and this is key4 containing USER - {key4}
+      cmd: "echo this is key2, containing PWD - {key2} and this is key4 containing USER - {key4}. ARB_SET_ME1 is empty: $ARB_SET_ME1"

--- a/pipelines/fileformat.yaml
+++ b/pipelines/fileformat.yaml
@@ -23,41 +23,40 @@ steps:
   - name: pypyr.steps.fileformat
     description: read a file from disk, do some substitutions, write back out.
     in:
-      fileFormatIn: ./testfiles/fileformat-in.1.txt
-      fileFormatOut: ./out/fileformat-out.txt
-  - name: pypyr.steps.contextclear
-    description: get rid of the previous fileFormat props, specifically so
-                 fileFormatOut doesn't still sit in context for the next step.
-    in:
-      contextClear:
-        - fileFormatOut
+      fileFormat:
+        in: ./testfiles/fileformat-in.1.txt
+        out: ./out/fileformat-out.txt
   - name: pypyr.steps.fileformat
     description: in-place edit, read a file from disk, do some substitutions,
                  overwrite the input file with the result.
     in:
-      fileFormatIn: ./testfiles/fileformat-in.1.txt
+      fileFormat:
+        in: ./testfiles/fileformat-in.1.txt
   - name: pypyr.steps.fileformat
     description: use a glob to format a whole lotta files in one go.
                  don't use outpath when you're globbing.
                  globbing implies in-place edits.
     in:
-      fileFormatIn: ./testfiles/??b/fileformat-in.*.txt
+      fileFormat:
+        in: ./testfiles/??b/fileformat-in.*.txt
   - name: pypyr.steps.fileformat
     description: use a list for multiple in paths to process.
                  each list item has globbing run on it.
                  don't use outpath when you're passing in a list.
                  globbing implies in-place edits.
     in:
-      fileFormatIn:
-        - ./testfiles/sub2/fileformat-in.sub.1.txt
-        - ./testfiles/sub2/**/*subsub*.txt
+      fileFormat:
+        in:
+          - ./testfiles/sub2/fileformat-in.sub.1.txt
+          - ./testfiles/sub2/**/*subsub*.txt
   - name: pypyr.steps.fileformat
     description: use a list for multiple in paths to process.
                  each list item has globbing run on it.
                  outpath uses / at end to show it's a dir.
                  this will flatten src dir hierarchy into the out dir.
     in:
-      fileFormatIn:
-        - ./testfiles/sub3/**/*.txt
-        - ./testfiles/sub2/*2*
-      fileFormatOut: ./out/sub3/
+      fileFormat:
+          in:
+            - ./testfiles/sub3/**/*.txt
+            - ./testfiles/sub2/*2*
+          out: ./out/sub3/

--- a/pipelines/fileformat.yaml
+++ b/pipelines/fileformat.yaml
@@ -1,0 +1,63 @@
+# WARNING: Will be working with ./out dir - if you have anything in there you
+# want to keep or not potentially overwrite, don't run this.
+#
+# This pipeline will leave the testfiles dir in a dirty state. Top tip: only
+# run this pipeline when git status is clean, and reset between runs with:
+# git reset --hard
+# this will remove any uncommited files in your workdir, so use with caution!
+#
+# To execute this pipeline, from repo directory shell something like:
+# pypyr fileformat
+steps:
+  - name: pypyr.steps.default
+    description: set some input context. will be substituting these values in the files.
+    in:
+      defaults:
+        k1: pypyr
+        k2: read
+        k3: hear
+  - name: pypyr.steps.safeshell
+    defaults: work with a copy of in-file, for easy re-runs of this pipeline
+    in:
+      cmd: cp ./testfiles/fileformat-in.txt ./testfiles/fileformat-in.1.txt
+  - name: pypyr.steps.fileformat
+    description: read a file from disk, do some substitutions, write back out.
+    in:
+      fileFormatIn: ./testfiles/fileformat-in.1.txt
+      fileFormatOut: ./out/fileformat-out.txt
+  - name: pypyr.steps.contextclear
+    description: get rid of the previous fileFormat props, specifically so
+                 fileFormatOut doesn't still sit in context for the next step.
+    in:
+      contextClear:
+        - fileFormatOut
+  - name: pypyr.steps.fileformat
+    description: in-place edit, read a file from disk, do some substitutions,
+                 overwrite the input file with the result.
+    in:
+      fileFormatIn: ./testfiles/fileformat-in.1.txt
+  - name: pypyr.steps.fileformat
+    description: use a glob to format a whole lotta files in one go.
+                 don't use outpath when you're globbing.
+                 globbing implies in-place edits.
+    in:
+      fileFormatIn: ./testfiles/??b/fileformat-in.*.txt
+  - name: pypyr.steps.fileformat
+    description: use a list for multiple in paths to process.
+                 each list item has globbing run on it.
+                 don't use outpath when you're passing in a list.
+                 globbing implies in-place edits.
+    in:
+      fileFormatIn:
+        - ./testfiles/sub2/fileformat-in.sub.1.txt
+        - ./testfiles/sub2/**/*subsub*.txt
+  - name: pypyr.steps.fileformat
+    description: use a list for multiple in paths to process.
+                 each list item has globbing run on it.
+                 outpath uses / at end to show it's a dir.
+                 this will flatten src dir hierarchy into the out dir.
+    in:
+      fileFormatIn:
+        - ./testfiles/sub3/**/*.txt
+        - ./testfiles/sub2/*2*
+      fileFormatOut: ./out/sub3/

--- a/pipelines/fileformatjson.yaml
+++ b/pipelines/fileformatjson.yaml
@@ -5,5 +5,6 @@ steps:
     description: read a yaml from json, do some substitutions, write back out.
     in:
       contextKeyHere: this value was set in the pipeline context!!
-      fileFormatJsonIn: ./testfiles/sample-with-substitutions.json
-      fileFormatJsonOut: ./out/sample-with-substitutions.json
+      fileFormatJson:
+        in: ./testfiles/sample-with-substitutions.json
+        out: ./out/sample-with-substitutions.json

--- a/pipelines/fileformatjson.yaml
+++ b/pipelines/fileformatjson.yaml
@@ -1,0 +1,9 @@
+# To execute this pipeline, from repo directory shell something like:
+# pypyr fileformatjson
+steps:
+  - name: pypyr.steps.fileformatjson
+    description: read a yaml from json, do some substitutions, write back out.
+    in:
+      contextKeyHere: this value was set in the pipeline context!!
+      fileFormatJsonIn: ./testfiles/sample-with-substitutions.json
+      fileFormatJsonOut: ./out/sample-with-substitutions.json

--- a/pipelines/fileformatyaml.yaml
+++ b/pipelines/fileformatyaml.yaml
@@ -5,5 +5,6 @@ steps:
     description: read a yaml from disk, do some substitutions, write back out.
     in:
       contextKeyHere: this value was set in the pipeline context!!
-      fileFormatYamlIn: ./testfiles/sample-with-substitutions.yaml
-      fileFormatYamlOut: ./out/sample-with-substitutions.yaml
+      fileFormatYaml:
+          in: [./testfiles/sample-with-substitutions.yaml, ./testfiles/sample-with-substitutions-duplicate.yaml]
+          out: ./out/

--- a/pipelines/filereplace-deprecated.yaml
+++ b/pipelines/filereplace-deprecated.yaml
@@ -1,0 +1,42 @@
+# WARNING: Will be working with ./out dir - if you have anything in there you
+# want to keep or not potentially overwrite, don't run this.
+# To execute this pipeline, from repo directory shell something like:
+# pypyr filereplace-deprecated
+# notice that using a context format expression to assign the value of
+# context['k1'] to ZZZ when doing the replacement
+steps:
+  - name: pypyr.steps.filereplace
+    in:
+      k1: wept
+      fileReplaceIn: ./testfiles/replacements.txt
+      fileReplaceOut: ./out/replacements.out.txt
+      fileReplacePairs:
+        XXX: pipe
+        YYY: pipe
+        ZZZ: "{k1}"
+  - name: pypyr.steps.filereplace
+    in:
+      fileReplaceIn: ./testfiles/replaceorder.txt
+      fileReplaceOut: ./out/replacementorder.out.txt
+      fileReplacePairs:
+        special: SPECIAL
+        # later replaces can affect earlier replaces
+        SPECIAL: XXX
+  - name: pypyr.steps.filereplace
+    description: use a list of globs instead of a single input file.
+                 each glob in the list fill be expanded.
+                 results written to the out directory.
+    in:
+      fileReplaceIn:
+        - ./testfiles/replace/sub/*.txt
+        - ./testfiles/replace/*
+      fileReplaceOut: ./out/replace/
+      fileReplacePairs:
+                XXX: pipe
+                YYY: pipe
+                ZZZ: "{k1}"
+                <<ARB>>: sung
+                <<ARB2>>: read
+                # notice escaping literal curlies by doubling
+                '{{arbbraces}}': valleys
+                manywords: wrote my happy songs

--- a/pipelines/filereplace.yaml
+++ b/pipelines/filereplace.yaml
@@ -8,35 +8,52 @@ steps:
   - name: pypyr.steps.filereplace
     in:
       k1: wept
-      fileReplaceIn: ./testfiles/replacements.txt
-      fileReplaceOut: ./out/replacements.out.txt
-      fileReplacePairs:
-        XXX: pipe
-        YYY: pipe
-        ZZZ: "{k1}"
+      fileReplace:
+        in: ./testfiles/replacements.txt
+        out: ./out/replacements.out.txt
+        replacePairs:
+          XXX: pipe
+          YYY: pipe
+          ZZZ: "{k1}"
   - name: pypyr.steps.filereplace
     in:
-      fileReplaceIn: ./testfiles/replaceorder.txt
-      fileReplaceOut: ./out/replacementorder.out.txt
-      fileReplacePairs:
-        special: SPECIAL
-        # later replaces can affect earlier replaces
-        SPECIAL: XXX
+      fileReplace:
+        in: ./testfiles/replaceorder.txt
+        out: ./out/replacementorder.out.txt
+        replacePairs:
+          special: SPECIAL
+          # later replaces can affect earlier replaces
+          SPECIAL: XXX
   - name: pypyr.steps.filereplace
     description: use a list of globs instead of a single input file.
                  each glob in the list fill be expanded.
                  results written to the out directory.
     in:
-      fileReplaceIn:
-        - ./testfiles/replace/sub/*.txt
-        - ./testfiles/replace/*
-      fileReplaceOut: ./out/replace/
-      fileReplacePairs:
-                XXX: pipe
-                YYY: pipe
-                ZZZ: "{k1}"
-                <<ARB>>: sung
-                <<ARB2>>: read
-                # notice escaping literal curlies by doubling
-                '{{arbbraces}}': valleys
-                manywords: wrote my happy songs
+      fileReplace:
+        in:
+          - ./testfiles/replace/sub/*.txt
+          - ./testfiles/replace/*
+        out: ./out/replace/
+        replacePairs:
+            XXX: pipe
+            YYY: pipe
+            ZZZ: "{k1}"
+            <<ARB>>: sung
+            <<ARB2>>: read
+            # notice escaping literal curlies by doubling
+            '{{arbbraces}}': valleys
+            manywords: wrote my happy songs
+  - name: pypyr.steps.safeshell
+    description: in-place edit will overwrite the in-file. make a copy 1st.
+    in:
+      cmd: cp ./testfiles/replacements.txt ./out/inplaceeditreplacements.txt
+  - name: pypyr.steps.filereplace
+    description: no out specified, means this will be an in-place edit.
+    in:
+      fileReplace:
+        in: ./out/inplaceeditreplacements.txt
+        out:
+        replacePairs:
+          XXX: pipe
+          YYY: pipe
+          ZZZ: "{k1}"

--- a/pipelines/filereplace.yaml
+++ b/pipelines/filereplace.yaml
@@ -22,3 +22,21 @@ steps:
         special: SPECIAL
         # later replaces can affect earlier replaces
         SPECIAL: XXX
+  - name: pypyr.steps.filereplace
+    description: use a list of globs instead of a single input file.
+                 each glob in the list fill be expanded.
+                 results written to the out directory.
+    in:
+      fileReplaceIn:
+        - ./testfiles/replace/sub/*.txt
+        - ./testfiles/replace/*
+      fileReplaceOut: ./out/replace/
+      fileReplacePairs:
+                XXX: pipe
+                YYY: pipe
+                ZZZ: "{k1}"
+                <<ARB>>: sung
+                <<ARB2>>: read
+                # notice escaping literal curlies by doubling
+                '{{arbbraces}}': valleys
+                manywords: wrote my happy songs

--- a/pipelines/tar-deprecated.yaml
+++ b/pipelines/tar-deprecated.yaml
@@ -1,0 +1,45 @@
+# WARNING: Will be working with ./out dir - if you have anything in there you
+# want to keep or not potentially overwrite, don't run this.
+# To execute this pipeline, from repo directory shell something like:
+# pypyr tar-deprecated fileName='myarchive'
+context_parser: pypyr.parser.keyvaluepairs
+steps:
+  - name: pypyr.steps.shell
+    description: archive examples to out, extract sample archives to out/originals
+    in:
+      cmd: mkdir out out/originals || true
+  - name: pypyr.steps.tar
+    description: default uses xz. you can test your archive with "cd out; tar xf testfile.tar.xz"
+    in:
+      tarArchive:
+        - in: testfiles
+          out: out/testfile.tar.xz
+  - name: pypyr.steps.contextclear
+    in:
+      contextClear:
+        - tarArchive
+  - name: pypyr.steps.tar
+    in:
+      tarExtract:
+        - in: ./out/testfile.tar.xz
+          out: out/originals
+  - name: pypyr.steps.contextclear
+    in:
+      contextClear:
+        - tarExtract
+  - name: pypyr.steps.tar
+    description: use gz and get fileName from context
+    in:
+      tarFormat: gz
+      tarArchive:
+        - in: ./testfiles
+          out: out/{fileName}.tar.gz
+  - name: pypyr.steps.tar
+    description: use plain tar (no compression)
+    in:
+      tarFormat: ''
+      tarArchive:
+        - in: ./testfiles
+          out: out/plainole.tar
+        - in: ./LICENSE
+          out: out/singlefile.tar

--- a/pipelines/tar.yaml
+++ b/pipelines/tar.yaml
@@ -11,35 +11,31 @@ steps:
   - name: pypyr.steps.tar
     description: default uses xz. you can test your archive with "cd out; tar xf testfile.tar.xz"
     in:
-      tarArchive:
-        - in: testfiles
-          out: out/testfile.tar.xz
-  - name: pypyr.steps.contextclear
-    in:
-      contextClear:
-        - tarArchive
+      tar:
+        archive:
+          - in: testfiles
+            out: out/testfile.tar.xz
   - name: pypyr.steps.tar
     in:
-      tarExtract:
-        - in: ./out/testfile.tar.xz
-          out: out/originals
-  - name: pypyr.steps.contextclear
-    in:
-      contextClear:
-        - tarExtract
+      tar:
+        extract:
+          - in: ./out/testfile.tar.xz
+            out: out/originals
   - name: pypyr.steps.tar
     description: use gz and get fileName from context
     in:
-      tarFormat: gz
-      tarArchive:
-        - in: ./testfiles
-          out: out/{fileName}.tar.gz
+      tar:
+        format: gz
+        archive:
+          - in: ./testfiles
+            out: out/{fileName}.tar.gz
   - name: pypyr.steps.tar
     description: use plain tar (no compression)
     in:
-      tarFormat: ''
-      tarArchive:
-        - in: ./testfiles
-          out: out/plainole.tar
-        - in: ./LICENSE
-          out: out/singlefile.tar
+      tar:
+        format: ''
+        archive:
+          - in: ./testfiles
+            out: out/plainole.tar
+          - in: ./LICENSE
+            out: out/singlefile.tar

--- a/testfiles/fileformat-in.1.txt
+++ b/testfiles/fileformat-in.1.txt
@@ -1,0 +1,2 @@
+pypyr sit thee down and write
+In a book that all may read

--- a/testfiles/fileformat-in.txt
+++ b/testfiles/fileformat-in.txt
@@ -1,0 +1,2 @@
+{k1} sit thee down and write
+In a book that all may {k2}

--- a/testfiles/replace/replacements.1.txt
+++ b/testfiles/replace/replacements.1.txt
@@ -1,0 +1,4 @@
+“Drop thy XXX, thy happy YYY,
+   Sing thy songs of happy cheer!”
+So I <<ARB>> the same again,
+   While he ZZZ with joy to hear.

--- a/testfiles/replace/replacements.2.txt
+++ b/testfiles/replace/replacements.2.txt
@@ -1,0 +1,4 @@
+"Piper, sit thee down and write
+In a book that all may <<ARB2>>—”
+So he vanished from my sight;
+And I plucked a hollow reed,

--- a/testfiles/replace/sub/oddoneout
+++ b/testfiles/replace/sub/oddoneout
@@ -1,0 +1,1 @@
+this aint goin nowhere

--- a/testfiles/replace/sub/replacements.3.txt
+++ b/testfiles/replace/sub/replacements.3.txt
@@ -1,0 +1,4 @@
+PIPING down the {arbbraces} wild,
+Piping songs of pleasant glee,	
+On a cloud I saw a child,
+And he laughing said to me:—

--- a/testfiles/replace/sub/replacements.4.txt
+++ b/testfiles/replace/sub/replacements.4.txt
@@ -1,0 +1,4 @@
+And I made a rural pen,
+And I stained the water clear,
+And I manywords
+Every child may joy to hear.

--- a/testfiles/sample-with-substitutions-duplicate.yaml
+++ b/testfiles/sample-with-substitutions-duplicate.yaml
@@ -1,0 +1,11 @@
+echoMe: this text lives inside a yaml file
+key4:
+  k41: k41value
+  k42:
+    - k42list1
+    # there's a comment here between 1 and 2. It won't be preserved.
+    - k42list2
+    - k42list3
+    - '{contextKeyHere}'
+  k43: True
+  k44: 77

--- a/testfiles/sample-with-substitutions.json
+++ b/testfiles/sample-with-substitutions.json
@@ -1,0 +1,18 @@
+{
+  "echoMe": "this text lives inside a yaml file",
+  "key4": {
+    "k41": "k41value",
+    "k42": [
+      "k42list1",
+      "k42list2",
+      {
+        "a": "b",
+        "c": "d"
+      },
+      "k42list3",
+      "{contextKeyHere}"
+    ],
+    "k43": true,
+    "k44": 77
+  }
+}

--- a/testfiles/sub/fileformat-in.sub.1.txt
+++ b/testfiles/sub/fileformat-in.sub.1.txt
@@ -1,0 +1,4 @@
+Pipe a song about a Lamb;
+So I piped with merry chear,
+{k1} pipe that song again— 
+So I piped, he wept to hear.

--- a/testfiles/sub/fileformat-in.sub.2.txt
+++ b/testfiles/sub/fileformat-in.sub.2.txt
@@ -1,0 +1,4 @@
+Drop thy pipe thy happy pipe
+Sing thy songs of happy chear,
+So I sung the same again
+While he wept with joy to {k3}

--- a/testfiles/sub/subsub/fileformat-in.subsub.1.txt
+++ b/testfiles/sub/subsub/fileformat-in.subsub.1.txt
@@ -1,0 +1,4 @@
+Pipe a song about a Lamb;
+So I piped with merry chear,
+Piper pipe that song again— 
+So I piped, he wept to {k3}.

--- a/testfiles/sub2/fileformat-in.sub.1.txt
+++ b/testfiles/sub2/fileformat-in.sub.1.txt
@@ -1,0 +1,4 @@
+Pipe a song about a Lamb;
+So I piped with merry chear,
+{k1} pipe that song again— 
+So I piped, he wept to hear.

--- a/testfiles/sub2/fileformat-in.sub.2.txt
+++ b/testfiles/sub2/fileformat-in.sub.2.txt
@@ -1,0 +1,4 @@
+Drop thy pipe thy happy pipe
+Sing thy songs of happy chear,
+So I sung the same again
+While he wept with joy to {k3}

--- a/testfiles/sub2/subsub/fileformat-in.subsub.1.txt
+++ b/testfiles/sub2/subsub/fileformat-in.subsub.1.txt
@@ -1,0 +1,4 @@
+Pipe a song about a Lamb;
+So I piped with merry chear,
+Piper pipe that song again— 
+So I piped, he wept to {k3}.

--- a/testfiles/sub2/subsub/subsubsub/fileformat-in.subsub.1.txt
+++ b/testfiles/sub2/subsub/subsubsub/fileformat-in.subsub.1.txt
@@ -1,0 +1,5 @@
+this was in subsubsub:
+Pipe a song about a Lamb;
+So I piped with merry chear,
+Piper pipe that song again—
+So I piped, he wept to {k3}.

--- a/testfiles/sub2/subsub/subsubsub/fileformat-in.subsub.2.txt
+++ b/testfiles/sub2/subsub/subsubsub/fileformat-in.subsub.2.txt
@@ -1,0 +1,5 @@
+this was in subsubsub:
+Pipe a song about a Lamb;
+So I piped with merry chear,
+Piper pipe that song again—
+So I piped, he wept to {k3}.

--- a/testfiles/sub3/fileformat-in.sub.1.txt
+++ b/testfiles/sub3/fileformat-in.sub.1.txt
@@ -1,0 +1,4 @@
+Pipe a song about a Lamb;
+So I piped with merry chear,
+{k1} pipe that song again— 
+So I piped, he wept to hear.

--- a/testfiles/sub3/fileformat-in.sub.2.txt
+++ b/testfiles/sub3/fileformat-in.sub.2.txt
@@ -1,0 +1,4 @@
+Drop thy pipe thy happy pipe
+Sing thy songs of happy chear,
+So I sung the same again
+While he wept with joy to {k3}

--- a/testfiles/sub3/subsub/fileformat-in.subsub.1.txt
+++ b/testfiles/sub3/subsub/fileformat-in.subsub.1.txt
@@ -1,0 +1,4 @@
+Pipe a song about a Lamb;
+So I piped with merry chear,
+Piper pipe that song again— 
+So I piped, he wept to {k3}.


### PR DESCRIPTION
- env, assert, tar uses new context input formats. 
- add debug example
- add file blobbing examples for filereplace, fileformat, fileformatjson, fileformatyaml. These also use new context input formats.