### PR TITLE
contextsetf ternary examples and envget

### DIFF
--- a/pipelines/contextset.yaml
+++ b/pipelines/contextset.yaml
@@ -19,3 +19,23 @@ steps:
       contextSet:
         echoMe: newKey
   - pypyr.steps.echo # this should echo echoMe, which now has the same value as XXX+invalue+XXX
+  - name: pypyr.steps.contextsetf
+    description: use py strings for conditional and ternary assignments.
+    in:
+      arb1: null
+      arb2: ''
+      arb3: eggymyvalue
+      arb4: [1,1,2,3,5,8]
+      contextSetf:
+        isNull: !py arb1 is None # make a bool based on None
+        isEmpty: !py bool(arb2) # use truthy, empty strings are false
+        ternaryResult: !py "'eggs' if arb3 == 'eggymyvalue' else 'ham'"
+        isIn: !py 10 in arb4 # bool if thing in list
+  - name: pypyr.steps.debug
+    in:
+      debug:
+        keys:
+          - isNull
+          - isEmpty
+          - ternaryResult
+          - isIn

--- a/pipelines/envget.yaml
+++ b/pipelines/envget.yaml
@@ -20,8 +20,20 @@ steps:
     in:
       echoMe: you'll only see me if THIS-ENV-PROB-DOESNT-EXIST didn't exist.
   - name: pypyr.steps.debug
+    comment: pump out the values so you can see for yourself. . .
     in:
       debug:
         keys:
           - saveMeHere
           - isSaveMeHereSet
+  - name: pypyr.steps.envget
+    description: you can also pass a single getitem, not a list
+    in:
+      envGet:
+        env: MACAVITY
+        key: theHiddenPaw
+        default: but macavity wasn't there!
+  - name: pypyr.steps.debug
+    in:
+      debug:
+        keys: theHiddenPaw

--- a/pipelines/envget.yaml
+++ b/pipelines/envget.yaml
@@ -1,0 +1,27 @@
+# To execute this pipeline, from repo directory shell something like:
+# pypyr envget
+steps:
+  - name: pypyr.steps.envget
+    description: get $env, if it doesn't exist, use default value instead
+    comment: notice how the yaml null will end up creating save-me-here
+             as None.
+    in:
+      envGet:
+        - env: THIS-ENV-PROB-DOESNT-EXIST
+          key: saveMeHere
+          default: null
+  - name: pypyr.steps.contextsetf
+    description: create a bool based on whether save-me-here has a value
+    in:
+      contextSetf:
+        isSaveMeHereSet: !py saveMeHere is not None
+  - name: pypyr.steps.echo
+    run: '{isSaveMeHereSet}'
+    in:
+      echoMe: you'll only see me if THIS-ENV-PROB-DOESNT-EXIST didn't exist.
+  - name: pypyr.steps.debug
+    in:
+      debug:
+        keys:
+          - saveMeHere
+          - isSaveMeHereSet

--- a/pipelines/magritte.yaml
+++ b/pipelines/magritte.yaml
@@ -1,5 +1,5 @@
   steps:
     - name: pypyr.steps.echo
-      description: Output echoMe
+      comment: output echoMe
       in:
         echoMe: Ceci n'est pas une pipe


### PR DESCRIPTION
- envget example pipelines
- ternary contextsetf examples
- Magritte uses new comment instead of description